### PR TITLE
Add Apple Music bang

### DIFF
--- a/src/lib/bang/music.ts
+++ b/src/lib/bang/music.ts
@@ -20,7 +20,7 @@ export const music = [
   d: "music.apple.com",   // Base domain
   s: "Apple Music",    // Display name
   sc: "Music", // Sub-category
-  t: "apl",         // Bang command
+  t: "am",         // Bang command
   u: "https://music.apple.com/us/search?term={{{s}}}"   // Search URL pattern
   }
 ];

--- a/src/lib/bang/music.ts
+++ b/src/lib/bang/music.ts
@@ -20,7 +20,7 @@ export const music = [
   d: "music.apple.com",   // Base domain
   s: "Apple Music",    // Display name
   sc: "Music", // Sub-category
-  t: "am",         // Bang command
+  t: "apl",         // Bang command
   u: "https://music.apple.com/us/search?term={{{s}}}"   // Search URL pattern
   }
 ];


### PR DESCRIPTION
After I saw that there was no bang for Apple Music, I did this in about 2 minutes. Thanks for making it so easy!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Apple Music as a search option, accessible via a new bang command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->